### PR TITLE
Add options support for discord.js adapter methods

### DIFF
--- a/packages/reacord/library/core/reacord-discord-js.ts
+++ b/packages/reacord/library/core/reacord-discord-js.ts
@@ -121,7 +121,7 @@ export class ReacordDiscordJs extends Reacord {
 						: event.channel
 
 				if (!channel.isTextBased()) {
-					raise(`Channel ${event} is not a text channel`)
+					raise(`Channel ${channel.id} is not a text channel`)
 				}
 
 				if (opts?.reply) {

--- a/packages/reacord/library/core/reacord-discord-js.ts
+++ b/packages/reacord/library/core/reacord-discord-js.ts
@@ -78,6 +78,7 @@ export class ReacordDiscordJs extends Reacord {
 	/**
 	 * Sends an ephemeral message as a reply to a command interaction.
 	 *
+   * @deprecated Use reacord.reply(content, { ephemeral: true })
 	 * @see https://reacord.mapleleaf.dev/guides/sending-messages
 	 */
 	override ephemeralReply(

--- a/packages/reacord/library/core/reacord.tsx
+++ b/packages/reacord/library/core/reacord.tsx
@@ -25,9 +25,6 @@ export abstract class Reacord {
 
 	abstract send(...args: unknown[]): ReacordInstance
 	abstract reply(...args: unknown[]): ReacordInstance
-	/** 
-   * @deprecated Use reacord.reply(content, { ephemeral: true })
-   */
 	abstract ephemeralReply(...args: unknown[]): ReacordInstance
 
 	protected handleComponentInteraction(interaction: ComponentInteraction) {

--- a/packages/reacord/library/core/reacord.tsx
+++ b/packages/reacord/library/core/reacord.tsx
@@ -25,6 +25,9 @@ export abstract class Reacord {
 
 	abstract send(...args: unknown[]): ReacordInstance
 	abstract reply(...args: unknown[]): ReacordInstance
+	/** 
+   * @deprecated Use reacord.reply(content, { ephemeral: true })
+   */
 	abstract ephemeralReply(...args: unknown[]): ReacordInstance
 
 	protected handleComponentInteraction(interaction: ComponentInteraction) {


### PR DESCRIPTION
This pull request should resolve #36 & #38 by implementing options argument for adapter methods and removing edit/delete validation.

Although PR is backwards compatible, there's a single somewhat breaking change & some codebase questions.

A breaking change would be channel renderer alternatively requiring `Message` event for reply to work
```typescript
private createChannelRenderer(
  event: string | Discord.Message,
  opts?: SendOptions,
) {
  // ...
``` 

I'm not sure if I need to make changes to `ChannelMessageRenderer` to add `reply` method. At the moment, validation executes inside `send` method.


